### PR TITLE
Fix pipe example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,8 @@ a filter can be implemented as follows:
 	(define (exec-pipe editor range cmd)
 	  (let-values (((in out _) (process cmd))
 	               ((lines) (editor-get-lines editor range)))
-	    (call-with-port
-	      out
-	      (lambda (port) (lines->port lines port)))
+	    (write-string (lines->string lines) out)
+	    (close-output-port out)
 	    (let ((recv (port->lines in)))
 	      (close-input-port in)
 	      (exec-delete editor range)


### PR DESCRIPTION
Used the definition from https://github.com/nmeum/edward-contrib/blob/master/edward-contrib.scm#L23-L24

Without this change, using the pipe command runs into an error:

```text
Error: unbound variable: lines->port

	Call history:

	ed.scm:17: scheme.base#call-with-port	 
	ed.scm:19: lines->port	 
	lib/ed/editor.scm:120: chicken.base#call/cc	 
	lib/ed/editor.scm:120: guard-k489	 
	lib/ed/editor.scm:120: g682	 
	lib/ed/editor.scm:122: editor-error?	 
	lib/ed/editor.scm:120: handler-k492	 
	lib/ed/editor.scm:120: g686	 
	lib/ed/editor.scm:120: scheme.base#raise-continuable	 
	lib/ed/editor.scm:120: chicken.base#call/cc	 
	lib/ed/editor.scm:120: guard-k489	 
	lib/ed/editor.scm:120: g682	 
	lib/ed/editor.scm:122: editor-error?	 
	lib/ed/editor.scm:120: handler-k492	 
	lib/ed/editor.scm:120: g686	 
	lib/ed/editor.scm:120: scheme.base#raise-continuable	 	<--
```